### PR TITLE
Fix initializer to pull from `config`

### DIFF
--- a/ovos_tts_plugin_voicerss/__init__.py
+++ b/ovos_tts_plugin_voicerss/__init__.py
@@ -47,8 +47,8 @@ class VoiceRSSTTSPlugin(TTS):
         super(VoiceRSSTTSPlugin, self).__init__(
             lang, config, VoiceRSSTTSValidator(self), 'mp3')
         self.key = self.config.get("key")
-        self.voice = self.voice.get("voice")
-        self.rate = self.voice.get("speed", 0)
+        self.voice = self.config.get("voice")
+        self.rate = self.config.get("speed", 0)
 
     def get_tts(self, sentence, wav_file):
         with open(wav_file, "wb") as f:


### PR DESCRIPTION
In setting up voicerss I had the following error:

```
2023-08-30 19:19:04.463 - audio - ovos_plugin_manager.tts:create:142 - ERROR - The selected TTS plugin could not be loaded.
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/ovos_plugin_manager/tts.py", line 136, in create
    tts = clazz(tts_lang, tts_config)
  File "/home/mycroft/.local/lib/python3.10/site-packages/ovos_tts_plugin_voicerss/__init__.py", line 50, in __init__
    self.voice = self.voice.get("voice")
AttributeError: 'str' object has no attribute 'get'
2023-08-30 19:19:04.465 - audio - mycroft.audio.service:__init__:72 - ERROR - 'str' object has no attribute 'get'
```

When inspecting the code, I noticed the variable mismatch corrected in the attached patch.

After patching the file, TTS via voicerss works.